### PR TITLE
Fea/add groupstage crosstable

### DIFF
--- a/src/app/components/GroupCrosstable/index.js
+++ b/src/app/components/GroupCrosstable/index.js
@@ -1,0 +1,78 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { generateMatrixMatchesIndex } from 'app/helpers/utils'
+
+import Image from 'app/components/core/Image'
+import Table from 'app/components/core/Table'
+import Cell from 'app/components/core/Table/Cell'
+
+const GroupCrosstable = ({ group }) => {
+  const matrix = generateMatrixMatchesIndex(group.teams.length)
+  const matches = group.matches
+
+  const renderFirstRow = teams =>
+    <tr>
+      <Cell id='empty' />
+
+      {
+        teams.map(team =>
+          <Cell
+            id='team'
+            key={team.id}
+            align='center'
+          >
+            <Image src={team.logo} height='30px' />
+          </Cell>
+        )
+      }
+    </tr>
+
+  const renderCells = (teams, i) => {
+    const cells = []
+
+    for (let j = 0; j < teams.length; j++) {
+      cells.push(
+        <Cell key={j} align='center'>
+          {
+            i === j
+              ? '-'
+              : i < j
+                ? `${matches[matrix[i][j]].team1Score}x${matches[matrix[i][j]].team2Score}`
+                : `${matches[matrix[j][i]].team1Score}x${matches[matrix[j][i]].team2Score}`
+          }
+        </Cell>
+      )
+    }
+
+    return cells
+  }
+
+  return (
+    <Table>
+      {renderFirstRow(group.teams)}
+
+      {
+        group.teams.map((team, index) =>
+          <tr key={team.id}>
+            <Cell
+              id='team'
+              key={team.id}
+              align='center'
+            >
+              <Image src={team.logo} height='30px' />
+            </Cell>
+
+            {renderCells(group.teams, index)}
+          </tr>
+        )
+      }
+    </Table>
+  )
+}
+
+GroupCrosstable.propTypes = {
+  group: PropTypes.object,
+}
+
+export default GroupCrosstable

--- a/src/app/components/GroupCrosstable/styled.js
+++ b/src/app/components/GroupCrosstable/styled.js
@@ -1,0 +1,14 @@
+import styled from 'styled-components'
+
+export const Container = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+`
+
+export const Match = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 1rem;
+  flex-basis: 50%;
+`

--- a/src/app/components/League/index.js
+++ b/src/app/components/League/index.js
@@ -5,17 +5,19 @@ import { navigate } from '@reach/router'
 import { generateLeagueGroupStage } from 'app/helpers/utils'
 import teams from 'app/helpers/teams'
 
+import GroupCrosstable from 'app/components/GroupCrosstable'
+
 import Text from 'app/components/core/Text'
 import Button from 'app/components/core/Button'
 import Table from 'app/components/core/Table'
 import Cell from 'app/components/core/Table/Cell'
 
-import { Groups, Group } from './styled'
+import { Group, Tables } from './styled'
 
 const League = () => {
   const dispatch = useDispatch()
   const league = useSelector(state => state.league)
-  const columns = ['Team', 'Points']
+  const columns = ['Team', 'Score', 'Points']
 
   const handleClick = () => {
     navigate('team')
@@ -28,20 +30,20 @@ const League = () => {
   return (
     <div>
       <Text component='h1'>
-        League
+        {league.name}
       </Text>
       <Text padding='1rem 0 0 0'>
         {`youre playing ${league.name}`}
       </Text>
 
-      <Groups>
-        {
-          league.groups.map(group =>
-            <Group key={group.name}>
-              <Text component='h3' padding='0 0 1rem 0'>
-                {`Group ${group.name}`}
-              </Text>
+      {
+        league.groups.map(group =>
+          <Group key={group.name}>
+            <Text component='h3' padding='0 0 1rem 0'>
+              {`Group ${group.name}`}
+            </Text>
 
+            <Tables>
               <Table columns={columns}>
                 {
                   group.teams.map(team =>
@@ -52,17 +54,23 @@ const League = () => {
                         </Text>
                       </Cell>
 
-                      <Cell id='points'>
+                      <Cell id='score'>
+                        0-0-0
+                      </Cell>
+
+                      <Cell id='points' align='center'>
                         0
                       </Cell>
                     </tr>
                   )
                 }
               </Table>
-            </Group>
-          )
-        }
-      </Groups>
+
+              <GroupCrosstable group={group} />
+            </Tables>
+          </Group>
+        )
+      }
 
       <Button onClick={handleClick}>
         {'next >'}

--- a/src/app/components/League/styled.js
+++ b/src/app/components/League/styled.js
@@ -1,11 +1,16 @@
 import styled from 'styled-components'
 
-export const Groups = styled.div`
-  display: flex;
-  justify-content: center;
+export const Group = styled.div`
+  text-align: center;
   padding: 3rem 0;
 `
 
-export const Group = styled.div`
-  padding: 0 2rem;
+export const Tables = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  table {
+    margin: 0 3rem;
+  }
 `

--- a/src/app/components/core/Table/Cell/index.js
+++ b/src/app/components/core/Table/Cell/index.js
@@ -4,6 +4,7 @@ import theme from 'app/helpers/theme'
 
 const Cell = styled.td`
   max-width: ${({ width }) => width || 'unset'};
+  text-align: ${({ align }) => align || 'left'}
   
   ${
     ({ variant }) => variant &&

--- a/src/app/components/core/Table/index.js
+++ b/src/app/components/core/Table/index.js
@@ -26,11 +26,14 @@ const Table = ({ columns, children }) => {
 
   return (
     <CoreTable>
-      <thead>
-        <tr>
-          {renderColumns()}
-        </tr>
-      </thead>
+      {
+        columns &&
+          <thead>
+            <tr>
+              {renderColumns()}
+            </tr>
+          </thead>
+      }
 
       <tbody>
         {children}

--- a/src/app/components/core/Table/styled.js
+++ b/src/app/components/core/Table/styled.js
@@ -7,8 +7,11 @@ export const CoreTable = styled.table`
   border-collapse: collapse;
   color: ${theme.colors.white};
 
-  th, td {
+  th {
     text-align: left;
+  }
+  
+  th, td {
     padding: .5rem .8rem;
 
     &:first-child {

--- a/src/app/helpers/utils.js
+++ b/src/app/helpers/utils.js
@@ -58,6 +58,27 @@ export const getPlayerDefaultPortrait = () =>
 
 // -------------
 // league related
+export const generateGroupMatches = teams => {
+  const matches = []
+  let id = 0
+
+  for (let i = 0; i < teams.length; i++) {
+    for (let j = i + 1; j < teams.length; j++) {
+      matches.push(
+        {
+          id: id++,
+          team1: teams[i],
+          team2: teams[j],
+          team1Score: 0,
+          team2Score: 0,
+        }
+      )
+    }
+  }
+
+  return matches
+}
+
 export const generateLeagueGroupStage = (dispatch, teams) => {
   const teamCopy = [...teams]
   const groupSize = teamCopy.length >= 16 ? 8 : 4
@@ -66,20 +87,52 @@ export const generateLeagueGroupStage = (dispatch, teams) => {
 
   while (teamCopy.length) {
     const rng = Math.floor(Math.random() * teamCopy.length)
-    groupTeams = [...groupTeams, teamCopy[rng]]
+    groupTeams.push(teamCopy[rng])
     teamCopy.splice(rng, 1)
 
     if (teamCopy.length % groupSize === 0) {
+      const groupMatches = generateGroupMatches(groupTeams)
       groupLetter = String.fromCharCode(groupLetter.charCodeAt() + 1)
 
       dispatch(addGroup(
         {
           name: groupLetter,
           teams: groupTeams,
+          matches: groupMatches,
         }
       ))
 
       groupTeams = []
     }
   }
+}
+
+// this generates a matrix sizexsize in the following structure (for size = 4):
+//  [ --  n0  n1  n2 ]
+//  [ n0  --  n3  n4 ]
+//  [ n1  n3  --  n5 ]
+//  [ n2  n4  n5  -- ]
+//
+// this is used for populating the group stage matches crosstable
+// n is the index of the match (in group.matches array) that has to be rendered in its cell
+// example crosstable at https://liquipedia.net/dota2/The_International/2019/Group_Stage
+export const generateMatrixMatchesIndex = size => {
+  const matrix = []
+  let content = 0
+  let temp = []
+
+  for (let i = 0; i < size; i++) {
+    for (let j = 0; j < size; j++) {
+      i === j
+        ? temp.push('--')
+        : i < j
+          ? temp.push(content++)
+          : temp.push(matrix[j][i])
+    }
+
+    matrix.push(temp)
+    temp = []
+  }
+
+  return matrix
 }

--- a/src/app/redux/actions/league.js
+++ b/src/app/redux/actions/league.js
@@ -2,11 +2,3 @@ export const addGroup = group => ({
   type: 'ADD_GROUP',
   group: group,
 })
-
-export const addLowerMatch = () => ({
-  type: 'ADD_LOWER_MATCH',
-})
-
-export const addUpperMatch = () => ({
-  type: 'ADD_LOWER_MATCH',
-})

--- a/src/app/redux/reducers/league.js
+++ b/src/app/redux/reducers/league.js
@@ -12,29 +12,6 @@ const league = (state = initialState, action) => {
         ...state,
         groups: [...state.groups, action.group],
       }
-    case 'ADD_UPPER_MATCH':
-      return {
-        ...state,
-        upper: [
-          ...state.upper,
-          {
-            team1: action.team1,
-            team2: action.team2,
-          },
-        ],
-      }
-
-    case 'ADD_LOWER_MATCH':
-      return {
-        ...state,
-        lower: [
-          ...state.lower,
-          {
-            team1: action.team1,
-            team2: action.team2,
-          },
-        ],
-      }
 
     default:
       return state


### PR DESCRIPTION
added league Groupstage crosstable ([reference](https://liquipedia.net/dota2/The_International/2019/Group_Stage))

- removed unused leageu redux stuff
- added generateMatrixMatchesIndex utils function (documented in code)
- udpated core Table to render even if no _columns_ prop is given
- added align prop to core Table Cell
- added GroupCrosstable component
- added GroupCrosstable to League component